### PR TITLE
Added MP and NS to checkSegment

### DIFF
--- a/src/gisflu/credentials.py
+++ b/src/gisflu/credentials.py
@@ -69,6 +69,8 @@ class credentials:
             "PB1",
             "HE",
             "PB2",
+            "MP",
+            "NS"
         ]
 
         self.downloadWaitWindowId = None


### PR DESCRIPTION
Currently, the DNA sequences for segment 7 ("matrix") and segment 8 ("non-structural") cannot be downloaded. This pull request fixes this issue by adding the correct DNA keywords.

To download the DNA sequences for M and NS, GISAID requires the keywords "MP" and "NS". However, these are not currently included in the `segmentCheck` list, so they generate an error. The list has other keywords like "M1" and "NEP" which are appropriate to download protein sequences encoded on these segments.

I added the DNA keywords "MP" and "NS" to the `segmentCheck` list. I confirmed that they function correctly. Running the following code results in downloading the correct DNA sequences for the M and NS segements.

```cred = gisflu.login()
isolateIds = ["EPI_ISL_19185107", "EPI_ISL_19151100"]
gisflu.download(cred, isolateIds, downloadType="dna", segments=["MP", "NS"],
    filename="records.fasta")```