### PR TITLE
Revert "Added MP and NS to checkSegment"

### DIFF
--- a/src/gisflu/credentials.py
+++ b/src/gisflu/credentials.py
@@ -69,8 +69,6 @@ class credentials:
             "PB1",
             "HE",
             "PB2",
-            "MP",
-            "NS"
         ]
 
         self.downloadWaitWindowId = None


### PR DESCRIPTION
@william-swl I have been notified by GISAID that the PR I submitted qualifies as a violation of their terms of service.

I was surprised to learn this, as I had no malicious intent. My intention with this code was to ensure that sequence analysis can be reproducible. 

Regardless, I want to abide by their terms of service. Can you **please reverse this change as soon as possible** so that I can regain compliance?